### PR TITLE
Use insertion sort instead of sort.Stable (better performance and less GC pressure)

### DIFF
--- a/centroid.go
+++ b/centroid.go
@@ -19,3 +19,19 @@ func (c *Centroid) Merge(o Centroid) {
 	c.Count += o.Count
 	c.Mean += float64(o.Count) * (o.Mean - c.Mean) / float64(c.Count)
 }
+
+func insertionSort(A []Centroid, N int) {
+	// Simple insertion sort shamelessly stolen from wikipedia:
+	// https://en.wikipedia.org/wiki/Insertion_sort
+	// Also found in:
+	// Introduction to Algorithms by Cormen et al.
+	for i := 1; i < N; i++ {
+		k := A[i]
+		j := i - 1
+		for j >= 0 && A[j].Mean > k.Mean {
+			A[j+1] = A[j]
+			j = j - 1
+		}
+		A[j+1] = k
+	}
+}

--- a/centroid_test.go
+++ b/centroid_test.go
@@ -1,0 +1,39 @@
+package tdigest
+
+import (
+	"sort"
+	"testing"
+)
+
+type sortByMean []Centroid
+
+func (s sortByMean) Len() int           { return len(s) }
+func (s sortByMean) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s sortByMean) Less(i, j int) bool { return s[i].Mean < s[j].Mean }
+
+func TestInsertionSort(t *testing.T) {
+	Centroids1 := []Centroid{
+		Centroid{Mean: 10, Count: 1},
+		Centroid{Mean: 11, Count: 2},
+		Centroid{Mean: 12, Count: 3},
+		Centroid{Mean: 10, Count: 4},
+		Centroid{Mean: 16, Count: 5},
+		Centroid{Mean: 88, Count: 6},
+		Centroid{Mean: 17, Count: 7},
+		Centroid{Mean: 19, Count: 8},
+		Centroid{Mean: 99, Count: 9},
+	}
+	N := len(Centroids1)
+	Centroids2 := make([]Centroid, N)
+	copy(Centroids2, Centroids1)
+
+	insertionSort(Centroids1, len(Centroids1))
+	sort.Stable(sortByMean(Centroids2))
+
+	// Check that we get the same sorting
+	for i := 0; i < N; i++ {
+		if Centroids1[i] != Centroids2[i] {
+			t.Error("Mismatch at index: ", i)
+		}
+	}
+}

--- a/tdigest.go
+++ b/tdigest.go
@@ -1,15 +1,6 @@
 package tdigest
 
-import (
-	"math"
-	"sort"
-)
-
-type sortByMean []Centroid
-
-func (s sortByMean) Len() int           { return len(s) }
-func (s sortByMean) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s sortByMean) Less(i, j int) bool { return s[i].Mean < s[j].Mean }
+import "math"
 
 // MergingDigest amortizes computation by merging in fixed sized batches
 type MergingDigest struct {
@@ -79,7 +70,8 @@ func (digest *MergingDigest) Compress() {
 	if len(digest.unmerged) == 0 {
 		return
 	}
-	sort.Stable(sortByMean(digest.unmerged))
+	// Sort with a stable sorting algorithm
+	insertionSort(digest.unmerged, len(digest.unmerged))
 	sum := int64(0)
 	m := 0
 	i := 0

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -73,3 +73,18 @@ func BenchmarkDigest(b *testing.B) {
 	}
 	digest.Compress()
 }
+
+func BenchmarkDigestOverNormalDistribution10Values(b *testing.B) {
+	rand := rand.New(rand.NewSource(42))
+	digest := New(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// For each benchmark iteration we add 10k values, otherwise the number of
+		// allocations won't be observable.
+		for j := 0; j < 10000; j++ {
+			digest.Add(rand.NormFloat64()*4+8, 1)
+			digest.Add(rand.NormFloat64()*2+18, 1)
+		}
+	}
+	digest.Compress()
+}


### PR DESCRIPTION
Basically the `interface{}` casting magic is very slow.
Even worse it makes allocations, the two benchmarks shows before/after
adding the naive insertion sort implementation:

```
Before:
BenchmarkDigestOverNormalDistribution-8   7773315763 ns/op  2573680 B/op   78156 allocs/op
After:
BenchmarkDigestOverNormalDistribution-8   6224821116 ns/op    73680 B/op      31 allocs/op
```

Notice the dramatic difference in number of allocations.
Summary, `sort.Stable` uses a lot of allocations when operation on structs like `Centroid`. Clearly this hurts the GC, etc...

Reproduce tests with `go test -bench . -benchmem -memprofilerate 1`. You might have to adjust the number of iterations to get enough for the allocations to register.
